### PR TITLE
Fixes MAISTRA-1963: updates to SME are being propagated to the filter now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,8 @@ impl RootContext for HeaderAppendRootContext {
     }
 
     fn on_configure(&mut self, _plugin_configuration_size: usize) -> bool {
-        if self.header_content == "" {
-            if let Some(config_bytes) = self.get_configuration() {
-                self.header_content = str::from_utf8(config_bytes.as_ref()).unwrap().to_owned()
-            }
+        if let Some(config_bytes) = self.get_configuration() {
+            self.header_content = str::from_utf8(config_bytes.as_ref()).unwrap().to_owned()
         }
         true
     }


### PR DESCRIPTION
`on_configure` callback is invoked on each configuration change and is responsible for handling of config changes. This fixes a bug where configuration updates were lost if current config wasn't empty. 