### PR TITLE
MAISTRA-2413 Update for compatibility with new Wasm API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,100 +2,47 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ahash"
-version = "0.3.8"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-
-[[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
  "ahash",
- "autocfg",
 ]
 
 [[package]]
 name = "header-append-filter"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proxy-wasm",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
-
-[[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "proxy-wasm"
-version = "0.1.2"
-source = "git+https://github.com/dgn/proxy-wasm-rust-sdk#fa8512af02a14a7c23bfc82556ba7e4817cfe979"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5612e16bf2c7e7f824dde8c2f9735600adffcb08ce05e66d0a7db37786a6ca6d"
 dependencies = [
  "hashbrown",
  "log",
- "wee_alloc",
 ]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if",
- "libc",
- "memory_units",
- "winapi",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,14 @@ name = "header-append-filter"
 version = "0.1.1"
 dependencies = [
  "proxy-wasm",
+ "serde_json",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "log"
@@ -45,4 +52,27 @@ checksum = "5612e16bf2c7e7f824dde8c2f9735600adffcb08ce05e66d0a7db37786a6ca6d"
 dependencies = [
  "hashbrown",
  "log",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "serde"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,11 @@
 [package]
 name = "header-append-filter"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Daniel Grimm <dgrimm@redhat.com>"]
 edition = "2018"
 
 [dependencies]
-# Gotta use my fork because config reading is broken upstream
-proxy-wasm = { git = "https://github.com/dgn/proxy-wasm-rust-sdk" }
-# proxy-wasm = "0.1.2"
+proxy-wasm = "0.1.3"
 
 [lib]
 crate-type = ["cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 proxy-wasm = "0.1.3"
+serde_json = "1.0.62"
 
 [lib]
 crate-type = ["cdylib"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+VERSION = 2.1
 HUB ?= quay.io/maistra-dev
 
 build: oidc.wasm
@@ -16,7 +17,7 @@ container: clean build
 	mkdir build
 	cp container/manifest.yaml build/
 	cp extension.wasm build/
-	cd build && docker build -t ${HUB}/header-append-filter . -f ../container/Dockerfile
+	cd build && docker build -t ${HUB}/header-append-filter:${VERSION} . -f ../container/Dockerfile
 
 container.push: container
-	docker push ${HUB}/header-append-filter
+	docker push ${HUB}/header-append-filter:${VERSION}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Simple WASM extension written in Rust
+
+## Steps to build it
+
+Install `rust`, if not already installed:
+
+```sh
+$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Install `wasm32` target, if not already installed:
+
+```sh
+$ rustup target add wasm32-unknown-unknown
+```
+
+Build the extension:
+
+```sh
+$ make build
+```
+
+A file named `extension.wasm` was created in the current directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,15 +46,15 @@ impl RootContext for HeaderAppendRootContext {
         true
     }
 
-    fn create_http_context(&self, _context_id: u32, _root_context_id: u32) -> Box<dyn HttpContext> {
-        Box::new(HeaderAppendFilter{
+    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
+        Some(Box::new(HeaderAppendFilter{
             header_content: self.header_content.clone(),
-        })
+        }))
     
     }
 
-    fn get_type(&self) -> ContextType {
-        ContextType::HttpContext
+    fn get_type(&self) -> Option<ContextType> {
+        Some(ContextType::HttpContext)
     }
 
 }


### PR DESCRIPTION
You can now configure the names of the headers by passing a structured config.

/hold for now because we have to make sure not to break 2.0 acceptance tests. Will need to create branches