### PR TITLE
Enable link-time optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ serde_json = "1.0.62"
 [lib]
 crate-type = ["cdylib"]
 path = "src/lib.rs"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This decreases module size from 1.6mb to 253kb

/hold until after release